### PR TITLE
add prepare script to prevent missing dist files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "flow": "flow",
     "lint": "eslint src",
     "build": "yarn transpile && yarn copy-packagejson && yarn copy-flow",
+    "prepare": "yarn build",
     "transpile": "babel ./src --out-dir ./dist/",
     "copy-packagejson": "cp package.json ./dist",
     "copy-flow": "cd src && pax -wrs'/\\.js$/\\.js\\.flow/' *.js ../dist"


### PR DESCRIPTION
Since 1.0.4 version this package does not working correctly. `main` field in package.json could not be resolved