### PR TITLE
Add support for Jest 28

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import * as crypto from "crypto";
 import * as yaml from "js-yaml";
-import type { Config, Path, TransformOptions, Transformer } from "./jest-types";
+import type { Config, Path, TransformOptions, TransformedSource, Transformer } from "./jest-types";
 
 const getCacheKey = (
   fileData: string,
@@ -24,10 +24,12 @@ export const process = (
   sourcePath: Path,
   config: Config,
   options?: TransformOptions
-): string => {
+): TransformedSource => {
   const result = yaml.load(sourceText);
   const json = JSON.stringify(result, undefined, "\t");
-  return `module.exports = ${json}`;
+  return {
+    code: `module.exports = ${json}`
+  };
 };
 
 const transformer: Transformer = {

--- a/src/jest-types.ts
+++ b/src/jest-types.ts
@@ -6,6 +6,10 @@ export type TransformOptions = {
   watch: boolean;
 };
 
+export type TransformedSource = {
+  code: string;
+};
+
 export type Transformer = {
   canInstrument?: boolean;
 
@@ -21,5 +25,5 @@ export type Transformer = {
     sourcePath: Path,
     config: Config,
     options?: TransformOptions
-  ) => string;
+  ) => TransformedSource;
 };


### PR DESCRIPTION
Fix #16 
Jest 28 breaks `yaml-jest` cuz process() and processAsync() methods of a custom [transformer module](https://jestjs.io/docs/code-transformation) cannot return a string.
[Upgrade Guides Transformer](https://jestjs.io/docs/upgrading-to-jest28#transformer)